### PR TITLE
Match the mapper select method by supporting WHERE conditions

### DIFF
--- a/src/Transit.php
+++ b/src/Transit.php
@@ -108,13 +108,13 @@ class Transit
         return $this->plan;
     }
 
-    public function select(string $domainClass) : TransitSelect
+    public function select(string $domainClass, array $whereEquals = []) : TransitSelect
     {
         $handler = $this->getHandler($domainClass);
 
         return new TransitSelect(
             $this,
-            $this->atlas->select($handler->getMapperClass()),
+            $this->atlas->select($handler->getMapperClass(), $whereEquals),
             $handler->getSourceMethod('fetch'),
             $domainClass
         );


### PR DESCRIPTION
Looking through the code I couldn't see any reason why this shouldn't be implemented? I noticed in `Atlas\Transit\Transit` there was a `@todo` mentioning having `TransitSelect` extend `MapperSelect` which if implemented would make this PR redundant, but I had a particular use-case where this was needed.

I'll look at trying to increase the test coverage when I have time.