### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "atlas/orm": "~3.0"
+        "atlas/orm": "^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -21,7 +21,7 @@
         }
     },
     "require-dev": {
-        "atlas/testing": "~1.0",
+        "atlas/testing": "^1.0",
         "pds/skeleton": "~1.0",
         "phpunit/phpunit": "~6.0"
     },


### PR DESCRIPTION
Allow Atlas/ORM 3.1 and superiors, but not 4.x.