### PR TITLE
Updates the required PHP version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": "^7.2",
         "atlas/orm": "^3.0"
     },
     "autoload": {


### PR DESCRIPTION
The object typehint requires PHP 7.2 or higher.

https://php.net/manual/migration72.new-features.php#migration72.new-features.object-type