### PR TITLE
New Transit::attach() method to attach domain to the current context

### DIFF
--- a/src/Transit.php
+++ b/src/Transit.php
@@ -68,6 +68,24 @@ class Transit
         );
     }
 
+    /**
+     * Attach a domain object to plan.
+     *
+     * @param \Atlas\Transit\object $domain
+     *
+     * @return \Atlas\Transit\Transit
+     * @throws \Atlas\Transit\Exception
+     */
+    public function attach(object $domain): Transit
+    {
+        $handler = $this->handlerLocator->get($domain);
+        /** @var \Atlas\Mapper\Record $record */
+        $record = $handler->updateSource($domain, $this->plan);
+        $record->getRow()->init('');
+
+        return $this;
+    }
+
     // PLAN TO insert/update
     public function store(object $domain) : void
     {

--- a/src/Transit.php
+++ b/src/Transit.php
@@ -71,7 +71,7 @@ class Transit
     /**
      * Attach a domain object to plan.
      *
-     * @param \Atlas\Transit\object $domain
+     * @param object $domain
      *
      * @return \Atlas\Transit\Transit
      * @throws \Atlas\Transit\Exception

--- a/tests/TransitTest.php
+++ b/tests/TransitTest.php
@@ -533,4 +533,29 @@ class TransitTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(101, $actual['responses'][0]['responseId']);
         $this->assertSame(14, $actual['responses'][0]['author']['authorId']);
     }
+
+    public function testAttach()
+    {
+        // Creation of author in first context
+        $entity = new Author('Author');
+        $this->transit->store($entity);
+        $this->transit->persist();
+
+        // New transit class for new context
+        $secondTransit = FakeTransit::new(
+            $this->atlas,
+            'Atlas\\Testing\\DataSource\\'
+        );
+        $secondTransit->attach($entity);
+
+        // Modify entity after attach to context
+        $entity->setName('Arthur 2123 fdgfd');
+
+        $secondTransit->store($entity);
+        $secondTransit->persist();
+
+        /** @var \Atlas\Mapper\Record $record */
+        $record = $secondTransit->getStorage()->offsetGet($entity);
+        $this->assertEquals('UPDATED', $record->getRow()->getStatus());
+    }
 }


### PR DESCRIPTION
New Transit::attach() method who permit to add a domain to the handler storage.
It's permit to update a domain from another context, without fetch domain again before ; like domain getted from session.

Similar with Doctrine: https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/cookbook/entities-in-session.html

Issue: https://github.com/atlasphp/Atlas.Transit/issues/15